### PR TITLE
Fix bug in assign reviewer workflow

### DIFF
--- a/.github/reviewer-lottery.yml
+++ b/.github/reviewer-lottery.yml
@@ -1,0 +1,10 @@
+groups:
+  - name: devs
+    reviewers: 1
+    usernames:
+      - samuelhilpert
+      - JaredHeinrich
+      - rickertmar
+      - val-cze
+      - emesercz 
+      - m0nika6

--- a/.github/workflows/pr_assign_reviewer.yml
+++ b/.github/workflows/pr_assign_reviewer.yml
@@ -7,13 +7,10 @@ on:
     types: [opened, ready_for_review, reopened]
 
 jobs:
-  example_assign_reviews:
+  assign_reviews:
     runs-on: ubuntu-latest
-    name: Assign Reviewer
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Assign random reviewers to PR
-        uses: ihs7/action-reviewer-roulette@v1
-        with:
-          number-of-reviewers: 1
+    - uses: actions/checkout@v4
+    - uses: uesteibar/reviewer-lottery@v3
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/tagebuch.md
+++ b/tagebuch.md
@@ -10,11 +10,19 @@
 
 ### Datum: 2024-10-02
 - **Entwickler**: Samuel
-- **Dauer**:  3 Stunden
-- **Arbeit**: Research zur Einbindung von Plugin in Openstack
+- **Dauer**: 3 Stunden
+- **Arbeit**: Research zur Einbindung von Plugin in OpenStack
 
 ---
 
-### Datum: YYYY-MM-DD
+### Datum: 2024-10-02
+- **Entwickler**: Jared
+- **Dauer**: 4 Stunden
+- **Arbeit**: Research und Support bei Installation von OpenStack
+
+---
+
+### Datum: 2024-MM-DD
+- **Entwickler**: Name
 - **Dauer**: z.B. 1,5 Stunden
 - **Arbeit**: Kurze Beschreibung der Aufgabe


### PR DESCRIPTION
Changed the github action that is used for reviewer assigning. The previous action only assigned active contibuters of the repo to pull requests.