### PR TITLE
ensured that behaviour of update is as expected with put method

### DIFF
--- a/eduvmstorebackend/eduvmstore/tests/test_api.py
+++ b/eduvmstorebackend/eduvmstore/tests/test_api.py
@@ -122,6 +122,7 @@ class AppTemplateViewSetTests(APITestCase):
         response = self.client.put(url, data, format='json', **self.get_auth_headers())
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.data['name'], name)
+        self.assertIsNotNone(response.data['updated_at'])
         self.assertEqual(response.data["instantiation_attributes"][0]["name"],
                          updated_instantiation_attributes_name)
         self.assertEqual(response.data["approved"], False)


### PR DESCRIPTION
Ensured that the update (put) endpoint works as expected:

if an optional attribute is not passed, it is instantiated with none
read_only_fields stay with their value
if a field has a default, the default is used for instantiation