### PR TITLE
Util version check

### DIFF
--- a/eduvmstorebackend/eduvmstore/api/serializers.py
+++ b/eduvmstorebackend/eduvmstore/api/serializers.py
@@ -5,7 +5,7 @@ from typing import Dict, List
 from rest_framework import serializers
 from eduvmstore.db.models import (AppTemplates, Users, Roles, AppTemplateInstantiationAttributes,
                                   AppTemplateAccountAttributes, Favorites, AppTemplateSecurityGroups)
-from eduvmstore.db.operations.app_templates import has_version_suffix, extract_version_suffix
+from eduvmstore.utils.string_utils import has_version_suffix, extract_version_suffix
 
 logger = logging.getLogger("eduvmstore_logger")
 class AppTemplateInstantiationAttributesSerializer(serializers.ModelSerializer):

--- a/eduvmstorebackend/eduvmstore/api/serializers.py
+++ b/eduvmstorebackend/eduvmstore/api/serializers.py
@@ -5,6 +5,7 @@ from typing import Dict, List
 from rest_framework import serializers
 from eduvmstore.db.models import (AppTemplates, Users, Roles, AppTemplateInstantiationAttributes,
                                   AppTemplateAccountAttributes, Favorites, AppTemplateSecurityGroups)
+from eduvmstore.db.operations.app_templates import check_name_collision
 from eduvmstore.utils.string_utils import has_version_suffix, extract_version_suffix
 
 logger = logging.getLogger("eduvmstore_logger")
@@ -103,11 +104,9 @@ class AppTemplateSerializer(serializers.ModelSerializer):
         :return: The validated name
         :raises: ValidationError if name has version suffix
         """
-        if has_version_suffix(name):
-            suffix = extract_version_suffix(name)
-            raise serializers.ValidationError(
-                f"App template name cannot end with the version suffix '{suffix}'. "
-            )
+        (collision, reason, context) = check_name_collision(name)
+        if collision:
+            raise serializers.ValidationError(reason.format(**context))
         return name
 
     def create_instantiation_attributes(self,

--- a/eduvmstorebackend/eduvmstore/api/views.py
+++ b/eduvmstorebackend/eduvmstore/api/views.py
@@ -1,7 +1,6 @@
 
 import logging
 from django.db.models import Q, QuerySet
-from django.core.exceptions import ObjectDoesNotExist
 from typing_extensions import override
 from rest_framework.request import Request
 

--- a/eduvmstorebackend/eduvmstore/api/views.py
+++ b/eduvmstorebackend/eduvmstore/api/views.py
@@ -15,8 +15,7 @@ from rest_framework.response import Response
 
 from eduvmstore.db.operations.app_templates import (approve_app_template,
                                                     check_name_collision,
-                                                    reject_app_template, has_version_suffix,
-                                                    extract_version_suffix)
+                                                    reject_app_template)
 from eduvmstore.utils.access_control import has_access_level
 
 logger = logging.getLogger('eduvmstore_logger')

--- a/eduvmstorebackend/eduvmstore/tests/test_db_operations_app_templates.py
+++ b/eduvmstorebackend/eduvmstore/tests/test_db_operations_app_templates.py
@@ -1,13 +1,11 @@
 import uuid
-from django.core.exceptions import ValidationError, ObjectDoesNotExist
 from django.test import TestCase
 from eduvmstore.config.access_levels import DEFAULT_ROLES
 from eduvmstore.db.models import AppTemplates, Users, Roles, AppTemplateInstantiationAttributes, \
     AppTemplateAccountAttributes
 from eduvmstore.db.operations.app_templates import (
     check_name_collision, approve_app_template, soft_delete_app_template, reject_app_template,
-    has_version_suffix, CollisionReason
-)
+    CollisionReason)
 
 class AppTemplateOperationsTests(TestCase):
 
@@ -75,22 +73,6 @@ class AppTemplateOperationsTests(TestCase):
         collision, reason, context = check_name_collision("NoCollision")
         self.assertFalse(collision)
         self.assertEqual(reason, CollisionReason.NO_COLLISION)
-
-    def test_has_version_suffix(self):
-        # Should return True for names with proper version suffixes
-        self.assertTrue(has_version_suffix("example-V21"))
-        self.assertTrue(has_version_suffix("template-V1"))
-        self.assertTrue(has_version_suffix("long name with spaces-V0"))
-        self.assertTrue(has_version_suffix("name-V999"))
-
-        # Should return False for names without version suffixes
-        self.assertFalse(has_version_suffix("app_templateITIL3"))
-        self.assertFalse(has_version_suffix("V1"))  # No hyphen
-        self.assertFalse(has_version_suffix("template-v1"))  # Lowercase v
-        self.assertFalse(has_version_suffix("template-V"))  # No digits
-        self.assertFalse(has_version_suffix("template-V1a"))  # Non-digit after number
-        self.assertFalse(has_version_suffix("template-V1-suffix"))  # Something after
-        self.assertFalse(has_version_suffix("template V1"))  # Space instead of hyphen
 
     def test_approves_app_template_successfully(self):
         approved_app_template = approve_app_template(self.app_template.id)

--- a/eduvmstorebackend/eduvmstore/tests/test_string_utils.py
+++ b/eduvmstorebackend/eduvmstore/tests/test_string_utils.py
@@ -1,0 +1,45 @@
+from django.test import TestCase
+from eduvmstore.utils.string_utils import has_version_suffix, extract_version_suffix, create_version_pattern
+
+class AppTemplateOperationsTests(TestCase):
+    def test_has_version_suffix(self):
+        # Should return True for names with proper version suffixes
+        self.assertTrue(has_version_suffix("example-V21"))
+        self.assertTrue(has_version_suffix("template-V1"))
+        self.assertTrue(has_version_suffix("long name with spaces-V0"))
+        self.assertTrue(has_version_suffix("name-V999"))
+
+        # Should return False for names without version suffixes
+        self.assertFalse(has_version_suffix("app_templateITIL3"))
+        self.assertFalse(has_version_suffix("V1"))  # No hyphen
+        self.assertFalse(has_version_suffix("template-v1"))  # Lowercase v
+        self.assertFalse(has_version_suffix("template-V"))  # No digits
+        self.assertFalse(has_version_suffix("template-V1a"))  # Non-digit after number
+        self.assertFalse(has_version_suffix("template-V1-suffix"))  # Something after
+        self.assertFalse(has_version_suffix("template V1"))  # Space instead of hyphen
+
+    def test_extract_version_suffix(self):
+        # Should extract version suffixes correctly
+        self.assertEqual(extract_version_suffix("example-V21"), "-V21")
+        self.assertEqual(extract_version_suffix("template-V1"), "-V1")
+        self.assertEqual(extract_version_suffix("long name with spaces-V0"), "-V0")
+        self.assertEqual(extract_version_suffix("name-V999"), "-V999")
+
+        # Should return empty string for invalid or missing version suffixes
+        self.assertEqual(extract_version_suffix("app_templateITIL3"), "")
+        self.assertEqual(extract_version_suffix("V1"), "")
+        self.assertEqual(extract_version_suffix("template-v1"), "")
+        self.assertEqual(extract_version_suffix("template-V"), "")
+        self.assertEqual(extract_version_suffix("template-V1a"), "")
+        self.assertEqual(extract_version_suffix("template-V1-suffix"), "")
+        self.assertEqual(extract_version_suffix("template V1"), "")
+
+    def test_create_version_pattern(self):
+        # Should create correct patterns for simple names
+        self.assertEqual(create_version_pattern("template"), r"^template-V\d+$")
+        self.assertEqual(create_version_pattern("example"), r"^example-V\d+$")
+
+        # Should escape special regex characters in names
+        self.assertEqual(create_version_pattern("test.template"), r"^test\.template-V\d+$")
+        self.assertEqual(create_version_pattern("test+name"), r"^test\+name-V\d+$")
+        self.assertEqual(create_version_pattern("name[1]"), r"^name\[1\]-V\d+$")

--- a/eduvmstorebackend/eduvmstore/utils/string_utils.py
+++ b/eduvmstorebackend/eduvmstore/utils/string_utils.py
@@ -1,0 +1,38 @@
+import re
+
+# Pattern to match version suffixes in AppTemplate names.
+# This pattern is forbidden as it is automatically used for approved AppTemplates
+VERSION_SUFFIX_PATTERN = r'-V\d+$'
+
+def has_version_suffix(name: str) -> bool:
+    """
+    Check if the given AppTemplate name has a version suffix.
+    Examples are '-V1', '-V2', etc.
+
+    :param str name: The name of the AppTemplate to check
+    :return: True if a version suffix is found, False otherwise
+    :rtype: bool
+    """
+    return bool(re.search(VERSION_SUFFIX_PATTERN, name))
+
+
+def extract_version_suffix(name: str) -> str:
+    """
+    Extract the version suffix from an AppTemplate name if present.
+
+    :param str name: The name to check
+    :return: The extracted version suffix or empty string if none found
+    :rtype: str
+    """
+    match = re.search(VERSION_SUFFIX_PATTERN, name)
+    return match.group(0) if match else ""
+
+def create_version_pattern(name: str) -> str:
+    """
+    Create a regex pattern to match versioned templates with the given base name.
+
+    :param str name: The base name to create the pattern for
+    :return: The regex pattern for matching versioned templates
+    :rtype: str
+    """
+    return f"^{re.escape(name)}{VERSION_SUFFIX_PATTERN}"


### PR DESCRIPTION
Moved the version names to a utility module as a cleaner approach.

Ensured that you cannot create an appTemplate where there is a an approved but not the original appTemplate existing.