### PR TITLE
Fix user delete

### DIFF
--- a/backend_setup.md
+++ b/backend_setup.md
@@ -22,7 +22,7 @@ SECRET_KEY=<your-secret-key>
 DEBUG=<True-or-False>
 ALLOWED_HOSTS=localhost,127.0.0.1,0.0.0.0,<your-backend-host-ip>
 CORS_ALLOW_ALL_ORIGINS=<True-or-False>
-OPENSTACK_AUTH_URL=<your-openstack-auth-url>
+OPENSTACK_AUTH_URL=<your-openstack-auth-url (e.g., 1.1.1.1/identity/)>
 SQLITE_DB_NAME=db.sqlite3
 ```
 

--- a/eduvmstorebackend/eduvmstore/api/views.py
+++ b/eduvmstorebackend/eduvmstore/api/views.py
@@ -1,4 +1,6 @@
 import logging
+
+from django.core.exceptions import ValidationError, ObjectDoesNotExist
 from django.db.models import Q, QuerySet
 from typing_extensions import override
 from rest_framework.request import Request
@@ -14,6 +16,7 @@ from rest_framework.response import Response
 from eduvmstore.db.operations.app_templates import (approve_app_template,
                                                     check_name_collision,
                                                     reject_app_template)
+from eduvmstore.db.operations.users import delete_user
 from eduvmstore.utils.access_control import has_access_level
 
 logger = logging.getLogger('eduvmstore_logger')
@@ -272,6 +275,30 @@ class UserViewSet(viewsets.ModelViewSet):
 
         return queryset
 
+    @override
+    def destroy(self, request: Request, *args, **kwargs) -> Response:
+        """
+        Delete a user and handle their AppTemplates:
+        - Private AppTemplates: deleted with related objects
+        - Public AppTemplates: transferred to the deleting admin user as updated creator
+        - If the user is deleting themselves and has public AppTemplates, return an error
+
+        :param Request request: The HTTP request object
+        :return: HTTP response with the deletion status
+        :rtype: Response
+        """
+        
+        user_to_delete = self.get_object()
+        current_user = request.myuser
+
+        try:
+            delete_user(user_to_delete, current_user)
+            return Response(status=status.HTTP_204_NO_CONTENT)
+        except ValidationError as e:
+            return Response(
+                {'error': str(e)},
+                status=status.HTTP_409_CONFLICT
+            )
 
 class RoleViewSet(viewsets.ModelViewSet):
     """

--- a/eduvmstorebackend/eduvmstore/api/views.py
+++ b/eduvmstorebackend/eduvmstore/api/views.py
@@ -290,13 +290,12 @@ class UserViewSet(viewsets.ModelViewSet):
         
         user_to_delete = self.get_object()
         current_user = request.myuser
-
         try:
             delete_user(user_to_delete, current_user)
             return Response(status=status.HTTP_204_NO_CONTENT)
         except ValidationError as e:
             return Response(
-                {'error': str(e)},
+                {'error': e.message},
                 status=status.HTTP_409_CONFLICT
             )
 

--- a/eduvmstorebackend/eduvmstore/db/operations/users.py
+++ b/eduvmstorebackend/eduvmstore/db/operations/users.py
@@ -78,8 +78,8 @@ def delete_user(user_to_delete: Users, current_user: Users = None) -> None:
     - Public AppTemplates: transferred to the deleting admin user as updated creator
     - If the user is deleting themselves and has public AppTemplates, raise a ValidationError
 
-    :param str user_to_delete_id: The UUID of the user to delete
-    :param str current_user_id: The UUID of the admin user performing the deletion
+    :param str user_to_delete: The UUID of the user to delete
+    :param str current_user: The UUID of the admin user performing the deletion
     :return: None
     :raises ObjectDoesNotExist: If the user is not found
     :raises ValidationError: If trying to delete self with public AppTemplates

--- a/eduvmstorebackend/eduvmstore/db/operations/users.py
+++ b/eduvmstorebackend/eduvmstore/db/operations/users.py
@@ -101,6 +101,7 @@ def delete_user(user_to_delete: Users, current_user: Users = None) -> None:
         private_app_templates.delete()
 
         # For public AppTemplates, transfer ownership to the current admin performing the deletion
+        # Updated at needs to be manually set as this is a direct sql update
         public_app_templates.update(
             creator_id=current_user,
             updated_at=timezone.now()

--- a/eduvmstorebackend/eduvmstore/db/operations/users.py
+++ b/eduvmstorebackend/eduvmstore/db/operations/users.py
@@ -97,7 +97,7 @@ def delete_user(user_to_delete: Users, current_user: Users = None) -> None:
             raise ValidationError("Cannot delete your own user while public AppTemplates are assigned to you."
                                   "Delete/Update them first.")
 
-        # Process AppTemplates (releated data is deleted automatically via model cascade)
+        # Process AppTemplates (related data is deleted automatically via model cascade)
         private_app_templates.delete()
 
         # For public AppTemplates, transfer ownership to the current admin performing the deletion

--- a/eduvmstorebackend/eduvmstore/db/operations/users.py
+++ b/eduvmstorebackend/eduvmstore/db/operations/users.py
@@ -2,8 +2,9 @@ from django.utils import timezone
 from django.core.exceptions import ObjectDoesNotExist, ValidationError
 from django.db import transaction
 from eduvmstore.config.access_levels import DEFAULT_ROLES
-from eduvmstore.db.models import Users
+from eduvmstore.db.models import Users, AppTemplates
 from eduvmstore.db.operations.roles import get_role_by_name, create_role
+
 from typing import Dict
 
 
@@ -69,6 +70,44 @@ def get_user_by_id(id: str) -> Users:
     except ObjectDoesNotExist:
         raise ObjectDoesNotExist(f"User with id {id} not found.")
 
+@transaction.atomic
+def delete_user(user_to_delete: Users, current_user: Users = None) -> None:
+    """
+    Delete a user and handle their AppTemplates:
+    - Private AppTemplates: deleted (related objects are deleted automatically via model cascade)
+    - Public AppTemplates: transferred to the deleting admin user as updated creator
+    - If the user is deleting themselves and has public AppTemplates, raise a ValidationError
+
+    :param str user_to_delete_id: The UUID of the user to delete
+    :param str current_user_id: The UUID of the admin user performing the deletion
+    :return: None
+    :raises ObjectDoesNotExist: If the user is not found
+    :raises ValidationError: If trying to delete self with public AppTemplates
+    """
+    try:
+        # Check if user is deleting themselves
+        is_self_deletion = (user_to_delete.id == current_user.id)
+
+        # Get user's AppTemplates
+        public_app_templates = AppTemplates.objects.filter(creator_id=user_to_delete, public=True)
+        private_app_templates = AppTemplates.objects.filter(creator_id=user_to_delete, public=False)
+
+        # Self-deletion with public AppTemplate not allowed
+        if is_self_deletion and public_app_templates.exists():
+            raise ValidationError("Cannot delete your own user while public AppTemplates are assigned to you."
+                                  "Delete/Update them first.")
+
+        # Process AppTemplates (releated data is deleted automatically via model cascade)
+        private_app_templates.delete()
+
+        # For public AppTemplates, transfer ownership to the current admin performing the deletion
+        public_app_templates.update(
+            creator_id=current_user,
+            updated_at=timezone.now()
+        )
+        user_to_delete.delete()
+    except ValidationError as e:
+        raise e
 
 # Currently unused, potential enhancement for the future
 def soft_delete_user(id: str) -> None:

--- a/eduvmstorebackend/eduvmstore/tests/test_api.py
+++ b/eduvmstorebackend/eduvmstore/tests/test_api.py
@@ -643,9 +643,7 @@ class UserViewSetTests(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
 
         # Check that admin is deleted
-        self.assertFalse(Users.objects.filter(id=self.admin_user.id, deleted=False).exists())
-        self.assertTrue(Users.objects.get(id=self.admin_user.id).deleted)
+        self.assertFalse(Users.objects.filter(id=self.admin_user.id).exists())
 
         # Check that private templates are deleted
-        self.assertFalse(AppTemplates.objects.filter(id=private_template.id, deleted=False).exists())
-        self.assertTrue(AppTemplates.objects.get(id=private_template.id).deleted)
+        self.assertFalse(AppTemplates.objects.filter(id=private_template.id).exists())

--- a/eduvmstorebackend/eduvmstore/tests/test_api.py
+++ b/eduvmstorebackend/eduvmstore/tests/test_api.py
@@ -553,7 +553,7 @@ class UserViewSetTests(APITestCase):
         target_user = Users.objects.create(role_id=self.normal_user.role_id)
 
         # Create public template owned by target user
-        public_template = AppTemplates.objects.create(
+        public_app_template = AppTemplates.objects.create(
             image_id=uuid.uuid4(),
             name="Target User Public Template-V1",
             description="A public template from target user",
@@ -566,7 +566,7 @@ class UserViewSetTests(APITestCase):
             fixed_cores=1.0,
         )
 
-        original_updated_at = public_template.updated_at
+        original_updated_at = public_app_template.updated_at
 
         # Delete the user
         url = reverse('user-detail', args=[target_user.id])
@@ -579,11 +579,11 @@ class UserViewSetTests(APITestCase):
         self.assertFalse(Users.objects.filter(id=target_user.id).exists())
 
         # Check that public template now belongs to the admin
-        public_template.refresh_from_db()
-        self.assertEqual(public_template.creator_id.id, self.admin_user.id)
+        public_app_template.refresh_from_db()
+        self.assertEqual(public_app_template.creator_id.id, self.admin_user.id)
 
         # Check that updated_at field has been changed
-        self.assertNotEqual(public_template.updated_at, original_updated_at)
+        self.assertNotEqual(public_app_template.updated_at, original_updated_at)
 
     @patch('eduvmstore.middleware.authentication_middleware.KeystoneAuthenticationMiddleware'
            '.validate_token_with_keystone')
@@ -592,7 +592,7 @@ class UserViewSetTests(APITestCase):
         mock_validate_token.return_value = {'id': self.admin_user.id, 'name': 'Admin'}
 
         # Create public template owned by admin
-        public_template = AppTemplates.objects.create(
+        AppTemplates.objects.create(
             image_id=uuid.uuid4(),
             name="Admin Public Template",
             description="A public template from admin",

--- a/eduvmstorebackend/eduvmstore/tests/test_api.py
+++ b/eduvmstorebackend/eduvmstore/tests/test_api.py
@@ -451,3 +451,201 @@ class FavoritesViewSetTests(APITestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(response.data), 1)
         self.assertEqual(response.data[0]['name'], self.app_template.name)
+
+
+class UserViewSetTests(APITestCase):
+
+    def create_user_and_role(self):
+        admin_role = Roles.objects.create(
+            name=DEFAULT_ROLES.get("EduVMStoreAdmin").get("name"),
+            access_level=DEFAULT_ROLES.get("EduVMStoreAdmin").get("access_level"),
+        )
+        user_role = Roles.objects.create(
+            name=DEFAULT_ROLES.get("EduVMStoreUser").get("name"),
+            access_level=DEFAULT_ROLES.get("EduVMStoreUser").get("access_level"),
+        )
+        admin_user = Users.objects.create(role_id=admin_role)
+        normal_user = Users.objects.create(role_id=user_role)
+        self.admin_user = admin_user
+        self.normal_user = normal_user
+
+    def get_auth_headers(self, token="valid_token"):
+        return {'HTTP_X_AUTH_TOKEN': token}
+
+    def setUp(self):
+        self.create_user_and_role()
+
+    @patch('eduvmstore.middleware.authentication_middleware.KeystoneAuthenticationMiddleware'
+           '.validate_token_with_keystone')
+    def test_normal_user_cannot_delete_user(self, mock_validate_token):
+        # Create a normal user
+        mock_validate_token.return_value = {'id': self.normal_user.id, 'name': 'User'}
+
+        # Create a user to delete
+        target_user = Users.objects.create(role_id=self.normal_user.role_id)
+
+        url = reverse('user-detail', args=[target_user.id])
+        response = self.client.delete(url, format='json', **self.get_auth_headers())
+
+        # Normal user should not be able to delete other users
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+        # Verify user still exists
+        self.assertTrue(Users.objects.filter(id=target_user.id).exists())
+
+    @patch('eduvmstore.middleware.authentication_middleware.KeystoneAuthenticationMiddleware'
+           '.validate_token_with_keystone')
+    def test_admin_deletes_user_with_private_templates(self, mock_validate_token):
+        # Admin user
+        mock_validate_token.return_value = {'id': self.admin_user.id, 'name': 'Admin'}
+
+        # Create user to delete
+        target_user = Users.objects.create(role_id=self.normal_user.role_id)
+
+        # Create private template owned by target user
+        private_template = AppTemplates.objects.create(
+            image_id=uuid.uuid4(),
+            name="Target User Private Template",
+            description="A private template from target user",
+            short_description="Private",
+            creator_id=target_user,
+            public=False,
+            approved=False,
+            fixed_ram_gb=1.0,
+            fixed_disk_gb=10.0,
+            fixed_cores=1.0,
+        )
+
+        # Create instantiation attribute for the private template
+        AppTemplateInstantiationAttributes.objects.create(
+            app_template_id=private_template,
+            name="JavaVersion"
+        )
+
+        # Create favorite entry for the private template
+        Favorites.objects.create(user_id=self.normal_user, app_template_id=private_template)
+
+        # Delete the user
+        url = reverse('user-detail', args=[target_user.id])
+        response = self.client.delete(url, format='json', **self.get_auth_headers())
+
+        # Should succeed
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+
+        # Check that user is deleted
+        self.assertFalse(Users.objects.filter(id=target_user.id).exists())
+
+        # Check that private templates are deleted
+        self.assertFalse(AppTemplates.objects.filter(id=private_template.id).exists())
+        self.assertFalse(
+            AppTemplateInstantiationAttributes.objects.filter(app_template_id=private_template.id).exists())
+
+        # Check that favorites are deleted as well
+        self.assertFalse(Favorites.objects.filter(app_template_id=private_template.id).exists())
+
+    @patch('eduvmstore.middleware.authentication_middleware.KeystoneAuthenticationMiddleware'
+           '.validate_token_with_keystone')
+    def test_admin_deletes_user_with_public_templates(self, mock_validate_token):
+        # Admin user
+        mock_validate_token.return_value = {'id': self.admin_user.id, 'name': 'Admin'}
+
+        # Create user to delete
+        target_user = Users.objects.create(role_id=self.normal_user.role_id)
+
+        # Create public template owned by target user
+        public_template = AppTemplates.objects.create(
+            image_id=uuid.uuid4(),
+            name="Target User Public Template-V1",
+            description="A public template from target user",
+            short_description="Public",
+            creator_id=target_user,
+            public=True,
+            approved=True,
+            fixed_ram_gb=1.0,
+            fixed_disk_gb=10.0,
+            fixed_cores=1.0,
+        )
+
+        original_updated_at = public_template.updated_at
+
+        # Delete the user
+        url = reverse('user-detail', args=[target_user.id])
+        response = self.client.delete(url, format='json', **self.get_auth_headers())
+
+        # Should succeed
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+
+        # Check that user is deleted
+        self.assertFalse(Users.objects.filter(id=target_user.id).exists())
+
+        # Check that public template now belongs to the admin
+        public_template.refresh_from_db()
+        self.assertEqual(public_template.creator_id.id, self.admin_user.id)
+
+        # Check that updated_at field has been changed
+        self.assertNotEqual(public_template.updated_at, original_updated_at)
+
+    @patch('eduvmstore.middleware.authentication_middleware.KeystoneAuthenticationMiddleware'
+           '.validate_token_with_keystone')
+    def test_admin_cannot_delete_self_with_public_templates(self, mock_validate_token):
+        # Admin user
+        mock_validate_token.return_value = {'id': self.admin_user.id, 'name': 'Admin'}
+
+        # Create public template owned by admin
+        public_template = AppTemplates.objects.create(
+            image_id=uuid.uuid4(),
+            name="Admin Public Template",
+            description="A public template from admin",
+            short_description="Public",
+            creator_id=self.admin_user,
+            public=True,
+            approved=True,
+            fixed_ram_gb=1.0,
+            fixed_disk_gb=10.0,
+            fixed_cores=1.0,
+        )
+
+        # Admin tries to delete themselves
+        url = reverse('user-detail', args=[self.admin_user.id])
+        response = self.client.delete(url, format='json', **self.get_auth_headers())
+
+        # Should fail
+        self.assertEqual(response.status_code, status.HTTP_409_CONFLICT)
+
+        # Verify admin still exists
+        self.assertTrue(Users.objects.filter(id=self.admin_user.id).exists())
+
+    @patch('eduvmstore.middleware.authentication_middleware.KeystoneAuthenticationMiddleware'
+           '.validate_token_with_keystone')
+    def test_admin_can_delete_self_with_only_private_templates(self, mock_validate_token):
+        # Admin user
+        mock_validate_token.return_value = {'id': self.admin_user.id, 'name': 'Admin'}
+
+        # Create private template owned by admin
+        private_template = AppTemplates.objects.create(
+            image_id=uuid.uuid4(),
+            name="Admin Private Template",
+            description="A private template from admin",
+            short_description="Private",
+            creator_id=self.admin_user,
+            public=False,
+            approved=False,
+            fixed_ram_gb=1.0,
+            fixed_disk_gb=10.0,
+            fixed_cores=1.0,
+        )
+
+        # Admin tries to delete themselves
+        url = reverse('user-detail', args=[self.admin_user.id])
+        response = self.client.delete(url, format='json', **self.get_auth_headers())
+
+        # Should succeed
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+
+        # Check that admin is deleted
+        self.assertFalse(Users.objects.filter(id=self.admin_user.id, deleted=False).exists())
+        self.assertTrue(Users.objects.get(id=self.admin_user.id).deleted)
+
+        # Check that private templates are deleted
+        self.assertFalse(AppTemplates.objects.filter(id=private_template.id, deleted=False).exists())
+        self.assertTrue(AppTemplates.objects.get(id=private_template.id).deleted)

--- a/eduvmstorebackend/eduvmstore/tests/test_db_operations_users.py
+++ b/eduvmstorebackend/eduvmstore/tests/test_db_operations_users.py
@@ -1,36 +1,41 @@
 from django.core.exceptions import ValidationError, ObjectDoesNotExist
 from django.test import TestCase
 from django.utils import timezone
-from eduvmstore.db.models import Roles, Users
-from eduvmstore.db.operations.users import create_user, get_user_by_id, soft_delete_user
+
+from eduvmstore.config.access_levels import DEFAULT_ROLES
+from eduvmstore.db.models import Roles, Users, AppTemplates
+from eduvmstore.db.operations.users import (create_user, get_user_by_id, soft_delete_user, delete_user)
 import uuid
 
 
 class UserOperationsTests(TestCase):
 
-    def create_role(self):
-        return Roles.objects.create(name="EduVMStoreAdmin", access_level=7000)
-
-    def create_user(self, role):
-        return Users.objects.create(
-            id=str(uuid.uuid4()),
-            role_id=role,
-            created_at=timezone.now(),
-            updated_at=timezone.now(),
-            deleted=False
+    def create_user_and_role(self):
+        admin_role = Roles.objects.create(
+            name=DEFAULT_ROLES.get("EduVMStoreAdmin").get("name"),
+            access_level=DEFAULT_ROLES.get("EduVMStoreAdmin").get("access_level"),
         )
+        user_role = Roles.objects.create(
+            name=DEFAULT_ROLES.get("EduVMStoreUser").get("name"),
+            access_level=DEFAULT_ROLES.get("EduVMStoreUser").get("access_level"),
+        )
+        admin_user = Users.objects.create(role_id=admin_role)
+        normal_user = Users.objects.create(role_id=user_role)
+        self.admin_role= admin_role
+        self.user_role = user_role
+        self.admin_user = admin_user
+        self.normal_user = normal_user
 
     def setUp(self):
-        self.role = self.create_role()
-        self.user = self.create_user(self.role)
+        self.create_user_and_role()
 
     def test_creates_user_successfully(self):
         user_data = {
             "id": str(uuid.uuid4()),
-            "role_id": self.role
+            "role_id": self.admin_role
         }
         user = create_user(user_data)
-        self.assertEqual(user.role_id, self.role)
+        self.assertEqual(user.role_id, self.admin_role)
         self.assertFalse(user.deleted)
 
     def test_does_not_create_user_with_invalid_data(self):
@@ -42,15 +47,118 @@ class UserOperationsTests(TestCase):
             create_user(user_data)
 
     def test_retrieves_user_by_id_successfully(self):
-        retrieved_user = get_user_by_id(self.user.id)
-        self.assertEqual(str(retrieved_user.id), self.user.id)
+        retrieved_user = get_user_by_id(self.admin_user.id)
+        self.assertEqual(retrieved_user.id, self.admin_user.id)
 
     def test_does_not_retrieve_nonexistent_user(self):
         with self.assertRaises(ObjectDoesNotExist):
             get_user_by_id(str(uuid.uuid4()))
 
     def test_soft_deletes_user_successfully(self):
-        soft_delete_user(self.user.id)
-        self.user.refresh_from_db()
-        self.assertTrue(self.user.deleted)
-        self.assertIsNotNone(self.user.deleted_at)
+        soft_delete_user(self.admin_user.id)
+        self.admin_user.refresh_from_db()
+        self.assertTrue(self.admin_user.deleted)
+        self.assertIsNotNone(self.admin_user.deleted_at)
+
+    def test_delete_user_with_private_templates(self):
+        # Create private template owned by target user
+        private_template = AppTemplates.objects.create(
+            id=str(uuid.uuid4()),
+            name="Private Template",
+            image_id=str(uuid.uuid4()),
+            description="A private template",
+            short_description="Private",
+            creator_id=self.normal_user,
+            public=False,
+            fixed_ram_gb=1.0,
+            fixed_disk_gb=10.0,
+            fixed_cores=1.0,
+        )
+
+        # Delete the user
+        delete_user(self.normal_user, self.admin_user)
+
+        # Check that user is deleted
+        self.assertFalse(Users.objects.filter(id=self.normal_user.id).exists())
+
+        # Check that private templates are deleted
+        self.assertFalse(AppTemplates.objects.filter(id=private_template.id).exists())
+
+    def test_delete_user_with_public_templates_transfers_ownership(self):
+        # Create public template owned by target user
+        public_template = AppTemplates.objects.create(
+            id=str(uuid.uuid4()),
+            image_id=str(uuid.uuid4()),
+            name="Public Template",
+            description="A public template",
+            short_description="Public",
+            creator_id=self.normal_user,
+            public=True,
+            fixed_ram_gb=1.0,
+            fixed_disk_gb=10.0,
+            fixed_cores=1.0,
+        )
+
+        # Track the original updated_at time
+        original_updated_at = public_template.updated_at
+
+        # Delete the user
+        delete_user(self.normal_user, self.admin_user)
+
+        # Check that user is deleted
+        self.assertFalse(Users.objects.filter(id=self.normal_user.id).exists())
+
+        # Check that public template ownership was transferred
+        public_template.refresh_from_db()
+        self.assertEqual(public_template.creator_id.id, self.admin_user.id)
+        self.assertNotEqual(public_template.updated_at, original_updated_at)
+
+    def test_user_cannot_delete_self_with_public_templates(self):
+        # Create public template owned by the user
+        public_template = AppTemplates.objects.create(
+            id=str(uuid.uuid4()),
+            name="Public Template",
+            image_id=str(uuid.uuid4()),
+            description="A public template",
+            short_description="Public",
+            creator_id=self.admin_user,
+            public=True,
+            fixed_ram_gb=1.0,
+            fixed_disk_gb=10.0,
+            fixed_cores=1.0,
+        )
+
+        # Try to delete self
+        with self.assertRaises(ValidationError) as context:
+            delete_user(self.admin_user, self.admin_user)
+
+        # Check error message
+        self.assertIn("Cannot delete your own user while public AppTemplates are assigned to you",
+                      str(context.exception))
+
+        # Verify user still exists
+        self.assertTrue(Users.objects.filter(id=self.admin_user.id).exists())
+
+    def test_user_can_delete_self_with_only_private_templates(self):
+        # Create private template owned by the user
+        private_template = AppTemplates.objects.create(
+            id=str(uuid.uuid4()),
+            name="Private Template",
+            image_id=str(uuid.uuid4()),
+            description="A private template",
+            short_description="Private",
+            creator_id=self.admin_user,
+            public=False,
+            fixed_ram_gb=1.0,
+            fixed_disk_gb=10.0,
+            fixed_cores=1.0,
+        )
+
+        # Delete self
+        delete_user(self.admin_user, self.admin_user)
+
+        # Check that user is deleted
+        self.assertFalse(Users.objects.filter(id=self.admin_user.id).exists())
+
+        # Check that private templates are deleted
+        self.assertFalse(AppTemplates.objects.filter(id=private_template.id).exists())

--- a/eduvmstorebackend/eduvmstore/tests/test_db_operations_users.py
+++ b/eduvmstorebackend/eduvmstore/tests/test_db_operations_users.py
@@ -86,7 +86,7 @@ class UserOperationsTests(TestCase):
 
     def test_delete_user_with_public_templates_transfers_ownership(self):
         # Create public template owned by target user
-        public_template = AppTemplates.objects.create(
+        public_app_template = AppTemplates.objects.create(
             id=str(uuid.uuid4()),
             image_id=str(uuid.uuid4()),
             name="Public Template",
@@ -100,7 +100,7 @@ class UserOperationsTests(TestCase):
         )
 
         # Track the original updated_at time
-        original_updated_at = public_template.updated_at
+        original_updated_at = public_app_template.updated_at
 
         # Delete the user
         delete_user(self.normal_user, self.admin_user)
@@ -109,13 +109,13 @@ class UserOperationsTests(TestCase):
         self.assertFalse(Users.objects.filter(id=self.normal_user.id).exists())
 
         # Check that public template ownership was transferred
-        public_template.refresh_from_db()
-        self.assertEqual(public_template.creator_id.id, self.admin_user.id)
-        self.assertNotEqual(public_template.updated_at, original_updated_at)
+        public_app_template.refresh_from_db()
+        self.assertEqual(public_app_template.creator_id.id, self.admin_user.id)
+        self.assertNotEqual(public_app_template.updated_at, original_updated_at)
 
     def test_user_cannot_delete_self_with_public_templates(self):
         # Create public template owned by the user
-        public_template = AppTemplates.objects.create(
+        AppTemplates.objects.create(
             id=str(uuid.uuid4()),
             name="Public Template",
             image_id=str(uuid.uuid4()),


### PR DESCRIPTION
Implemented user delete with tests so that
- a user and its private templates is deleted
- Public AppTemplates of the user change ownership to the deleting admin user
- There is an error message when a user tries to delete itself while having public appTemplates


Added some extra information on the auth_url in the .env as it was not precise enough
